### PR TITLE
update: added feature to pass accountType in the outbound call request.

### DIFF
--- a/dialoghandler/src/main/java/com/almende/dialog/accounts/AdapterConfig.java
+++ b/dialoghandler/src/main/java/com/almende/dialog/accounts/AdapterConfig.java
@@ -80,7 +80,10 @@ public class AdapterConfig {
 	Boolean anonymous=false;
 	
 	String owner=null;
-	//reducdant information to avoid linking to the accountServer to fetch the Account again
+	/**
+	 * reducdant information to avoid linking to the accountServer to fetch the Account again. 
+	 * This is the account type of the owner of the Adapter.
+	 */
 	AccountType accountType = null;
 	Collection<String> accounts=null;
 	//store adapter specific data
@@ -816,13 +819,27 @@ public class AdapterConfig {
         }
     }
     
+    /**
+     * reducdant information to avoid linking to the accountServer to fetch the
+     * Account again. <br>
+     * This is the account type of the owner of the Adapter.
+     * 
+     * @return
+     */
     public AccountType getAccountType() {
-    
+
         return accountType;
     }
-    
+
+    /**
+     * reducdant information to avoid linking to the accountServer to fetch the
+     * Account again. <br>
+     * This is the account type of the owner of the Adapter.
+     * 
+     * @param accountType
+     */
     public void setAccountType(AccountType accountType) {
-    
+
         this.accountType = accountType;
     }
     

--- a/dialoghandler/src/main/java/com/almende/dialog/adapter/ComsysVoiceXMLRESTProxy.java
+++ b/dialoghandler/src/main/java/com/almende/dialog/adapter/ComsysVoiceXMLRESTProxy.java
@@ -4,7 +4,6 @@ import java.io.UnsupportedEncodingException;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
-
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -12,7 +11,6 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
-
 import com.almende.dialog.accounts.AdapterConfig;
 import com.almende.dialog.accounts.Dialog;
 import com.almende.dialog.adapter.tools.Broadsoft;
@@ -166,7 +164,7 @@ public class ComsysVoiceXMLRESTProxy extends VoiceXMLRESTProxy {
 
         if (session.getQuestion() != null) {
             //play trial account audio if the account is trial
-            if (config.getAccountType() != null && config.getAccountType().equals(AccountType.TRIAL)) {
+            if (AccountType.TRIAL.equals(session.getAccountType())) {
                 session.addExtras(PLAY_TRIAL_AUDIO_KEY, "true");
             }
             return handleQuestion(question, config, formattedRemoteId, session);

--- a/dialoghandler/src/main/java/com/almende/dialog/adapter/VoiceXMLRESTProxy.java
+++ b/dialoghandler/src/main/java/com/almende/dialog/adapter/VoiceXMLRESTProxy.java
@@ -84,7 +84,6 @@ public class VoiceXMLRESTProxy {
     protected String TIMEOUT_URL = "timeout";
     protected String UPLOAD_URL = "upload";
     protected String EXCEPTION_URL = "exception";
-    @SuppressWarnings( "unused" )
     protected String host = "";
 
     public static void killSession(Session session) {
@@ -107,11 +106,12 @@ public class VoiceXMLRESTProxy {
      * @throws UnsupportedEncodingException
      */
     public static String dial(String address, String dialogIdOrUrl, AdapterConfig config, String accountId,
-        String bearerToken) throws Exception {
+        String bearerToken, AccountType accountType) throws Exception {
 
         HashMap<String, String> addressNameMap = new HashMap<String, String>();
         addressNameMap.put(address, "");
-        HashMap<String, String> result = dial(addressNameMap, dialogIdOrUrl, config, accountId, bearerToken);
+        HashMap<String, String> result = dial(addressNameMap, dialogIdOrUrl, config, accountId, bearerToken,
+            accountType);
         return result != null && !result.isEmpty() ? result.values().iterator().next() : null;
     }
 
@@ -135,11 +135,14 @@ public class VoiceXMLRESTProxy {
      * @param bearerToken
      *            Used to check if the account has enough credits to make a
      *            referral
+     * @param accountType
+     *            This is stored in the session and trial messages are played if
+     *            needed
      * @return
      * @throws Exception
      */
     public static HashMap<String, String> dial(Map<String, String> addressNameMap, String dialogIdOrUrl,
-        AdapterConfig config, String accountId, String bearerToken) throws Exception {
+        AdapterConfig config, String accountId, String bearerToken, AccountType accountType) throws Exception {
 
         HashMap<String, Session> sessionMap = new HashMap<String, Session>();
         HashMap<String, String> resultMap = new HashMap<String, String>();
@@ -212,6 +215,7 @@ public class VoiceXMLRESTProxy {
                             session = Session.createSession(config, formattedAddress);
                         }
                     }
+                    session.setAccountType(accountType);
                     session.killed = false;
                     session.setStartUrl(url);
                     session.setDirection("outbound");
@@ -400,6 +404,7 @@ public class VoiceXMLRESTProxy {
             if (isTest != null && Boolean.TRUE.equals(isTest)) {
                 session.setAsTestSession();
             }
+            session.setAccountType(config.getAccountType());
             session.setAccountId(config.getOwner());
             session.setRemoteAddress(externalRemoteID);
             session.storeSession();
@@ -457,7 +462,7 @@ public class VoiceXMLRESTProxy {
 
         if (session.getQuestion() != null) {
             //play trial account audio if the account is trial
-            if (config.getAccountType() != null && config.getAccountType().equals(AccountType.TRIAL)) {
+            if (AccountType.TRIAL.equals(session.getAccountType())) {
                 session.addExtras(PLAY_TRIAL_AUDIO_KEY, "true");
             }
             return handleQuestion(question, config, externalRemoteID, session);

--- a/dialoghandler/src/main/java/com/almende/dialog/model/Session.java
+++ b/dialoghandler/src/main/java/com/almende/dialog/model/Session.java
@@ -22,6 +22,7 @@ import com.almende.util.twigmongo.SortDirection;
 import com.almende.util.twigmongo.TwigCompatibleMongoDatastore;
 import com.almende.util.twigmongo.TwigCompatibleMongoDatastore.RootFindCommand;
 import com.almende.util.twigmongo.annotations.Id;
+import com.askfast.commons.entity.AccountType;
 import com.askfast.commons.utils.TimeUtils;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -76,6 +77,7 @@ public class Session{
     Question question = null;
     Map<String, String> extras = null;
     Integer retryCount = null;
+    AccountType accountType;
     @JsonIgnore
     boolean existingSession = false;
     
@@ -196,62 +198,6 @@ public class Session{
         session.existingSession = false;
         return session;
     }
-    
-//    @JsonIgnore
-//    public static Session getOrCreateSession(String internalSessionKey, String keyword) {
-//
-//        TwigCompatibleMongoDatastore datastore = new TwigCompatibleMongoDatastore();
-//        Session session = datastore.load(Session.class, internalSessionKey.toLowerCase());
-//        // If there is no session create a new one for the user
-//        if (session == null) {
-//            String[] split = internalSessionKey.split("\\|");
-//
-//            if (split.length == 3) {
-//                String type = split[0];
-//                String localaddress = split[1];
-//                AdapterConfig config = null;
-//                ArrayList<AdapterConfig> configs = AdapterConfig.findAdapters(type, localaddress, null);
-//                // This assume there is a default keyword
-//                if (configs.size() == 0) {
-//                    log.warning("No adapter found for new session type: " + type + " address: " + localaddress);
-//                    return null;
-//                }
-//                else if (configs.size() == 1) {
-//                    config = configs.get(0);
-//                    log.info("Adapter found for new session type: " + type + " address: " + localaddress);
-//                }
-//                else {
-//                    AdapterConfig defaultConfig = null;
-//                    for (AdapterConfig conf : configs) {
-//                        if (conf.getKeyword() == null) {
-//                            defaultConfig = conf;
-//                        }
-//                        else if (keyword != null && conf.getKeyword().equals(keyword)) {
-//                            config = conf;
-//                        }
-//                    }
-//                    if (config == null) {
-//                        log.warning("No adapter with right keyword so using default type: " + type + " address: " +
-//                                    localaddress);
-//                        config = defaultConfig;
-//                    }
-//                    else {
-//                        log.info("Adapter found with right keyword type: " + type + " address: " + localaddress +
-//                                 " keyword: " + keyword);
-//                    }
-//                }
-//                session = createSession(config, split[2]);
-//            }
-//            else {
-//                log.severe("getSession: incorrect key given:" + internalSessionKey);
-//            }
-//            session.existingSession = false;
-//        }
-//        else {
-//            session.existingSession = true;
-//        }
-//        return session;
-//    }
     
     public static Session createSession(AdapterConfig config, String remoteAddress) {
         return createSession(config, config.getMyAddress(), remoteAddress);
@@ -619,6 +565,16 @@ public class Session{
     public void setReleaseTimestamp( String releaseTimestamp )
     {
         this.releaseTimestamp = releaseTimestamp;
+    }
+    
+    public AccountType getAccountType() {
+        
+        return accountType;
+    }
+
+    public void setAccountType(AccountType accountType) {
+    
+        this.accountType = accountType;
     }
 
     /**

--- a/dialoghandler/src/main/java/com/almende/dialog/model/ddr/DDRRecord.java
+++ b/dialoghandler/src/main/java/com/almende/dialog/model/ddr/DDRRecord.java
@@ -791,6 +791,7 @@ public class DDRRecord
                     }
                     //attach the child and the parent ddrRecord Ids
                     updateParentAndChildDDRRecordIds(session);
+                    setAccountType(session.getAccountType());
                 }
             }
             addAdditionalInfo(Session.SESSION_KEY, sessionKeyMap);

--- a/dialoghandler/src/main/java/com/almende/dialog/util/DDRUtils.java
+++ b/dialoghandler/src/main/java/com/almende/dialog/util/DDRUtils.java
@@ -887,7 +887,6 @@ public class DDRUtils
                     }
                     ddrRecord.addStatusForAddress(address, status);
                 }
-                ddrRecord.setAccountType(config.getAccountType());
                 ddrRecord.addAdditionalInfo(DDR_MESSAGE_KEY, message);
                 ddrRecord.setSessionKeysFromMap(sessionKeyMap);
                 ddrRecord.addAdditionalInfo(DDRType.DDR_CATEGORY_KEY, category);

--- a/dialoghandler/src/test/java/com/almende/dialog/TestFramework.java
+++ b/dialoghandler/src/test/java/com/almende/dialog/TestFramework.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Method;
 import java.net.BindException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
 import javax.mail.MessagingException;
@@ -31,6 +32,7 @@ import com.almende.dialog.example.agent.TestServlet;
 import com.almende.dialog.model.Session;
 import com.almende.dialog.model.ddr.DDRPrice;
 import com.almende.dialog.model.ddr.DDRPrice.UnitType;
+import com.almende.dialog.model.ddr.DDRRecord;
 import com.almende.dialog.util.ServerUtils;
 import com.almende.util.DatastoreThread;
 import com.almende.util.ParallelInit;
@@ -314,5 +316,16 @@ public class TestFramework
                 log.info(String.format("Jetty is already running on port: %s. Ignoring request", jettyPort));
             }
         }
+    }
+    
+    /**
+     * Returns all the ddr records for this accountId
+     * 
+     * @param accountId
+     * @return
+     */
+    protected List<DDRRecord> getAllDdrRecords(String accountId) {
+
+        return DDRRecord.getDDRRecords(accountId, null, null, null, null, null, null, null, null, null, null);
     }
 }

--- a/dialoghandler/src/test/java/com/almende/dialog/adapter/CLXUSSDServletIT.java
+++ b/dialoghandler/src/test/java/com/almende/dialog/adapter/CLXUSSDServletIT.java
@@ -104,11 +104,11 @@ public class CLXUSSDServletIT extends TestFramework{
         DialogAgent dialogAgent = new DialogAgent();
         if (addressNameMap.size() > 1) {
             dialogAgent.outboundCallWithMap(addressNameMap, null, null, senderName, subject, url, null,
-                                            adapterConfig.getConfigId(), TEST_PUBLIC_KEY, "");
+                adapterConfig.getConfigId(), TEST_PUBLIC_KEY, "", adapterConfig.getAccountType());
         }
         else {
             dialogAgent.outboundCall(addressNameMap.keySet().iterator().next(), senderName, subject, url, null,
-                                     adapterConfig.getConfigId(), TEST_PUBLIC_KEY, "");
+                adapterConfig.getConfigId(), TEST_PUBLIC_KEY, "", adapterConfig.getAccountType());
         }
     }
 

--- a/dialoghandler/src/test/java/com/almende/dialog/adapter/MailServletIT.java
+++ b/dialoghandler/src/test/java/com/almende/dialog/adapter/MailServletIT.java
@@ -137,7 +137,7 @@ public class MailServletIT extends TestFramework
                                                           localAddressMail, localAddressMail, null);
         //send email
         new DialogAgent().outboundCall(remoteAddressEmail, "TEST", "TEST SUBJECT", url, null,
-                                       adapterConfig.getConfigId(), TEST_PUBLIC_KEY, null);
+            adapterConfig.getConfigId(), TEST_PUBLIC_KEY, null, adapterConfig.getAccountType());
         
         List<Session> allSessions = Session.getAllSessions();
         assertThat(allSessions.size(), Matchers.is(1));
@@ -316,7 +316,7 @@ public class MailServletIT extends TestFramework
         
         MailServlet mailServlet = new MailServlet();
         mailServlet.startDialog(addressNameMap, null, null, url, "test", "sendDummyMessageTest", adapterConfig,
-                                adapterConfig.getOwner());
+                                adapterConfig.getOwner(), adapterConfig.getAccountType());
         
         //assert that one session is created
         List<Session> allSessions = Session.getAllSessions();

--- a/dialoghandler/src/test/java/com/almende/dialog/adapter/NotificareServeletTest.java
+++ b/dialoghandler/src/test/java/com/almende/dialog/adapter/NotificareServeletTest.java
@@ -59,13 +59,11 @@ public class NotificareServeletTest extends TestFramework {
         DialogAgent dialogAgent = new DialogAgent();
         if (addressNameMap.size() > 1) {
             dialogAgent.outboundCallWithMap(addressNameMap, null, null, senderName, subject, url, null,
-                                            adapterConfig.getConfigId(), TEST_PUBLIC_KEY, "");
+                adapterConfig.getConfigId(), TEST_PUBLIC_KEY, "", adapterConfig.getAccountType());
         }
         else {
             dialogAgent.outboundCall(addressNameMap.keySet().iterator().next(), senderName, subject, url, null,
-                                     adapterConfig.getConfigId(), TEST_PUBLIC_KEY, "");
+                adapterConfig.getConfigId(), TEST_PUBLIC_KEY, "", adapterConfig.getAccountType());
         }
-
     }
-
 }

--- a/dialoghandler/src/test/java/com/almende/dialog/adapter/RouteSMSIT.java
+++ b/dialoghandler/src/test/java/com/almende/dialog/adapter/RouteSMSIT.java
@@ -222,11 +222,11 @@ public class RouteSMSIT extends TestFramework {
         DialogAgent dialogAgent = new DialogAgent();
         if (addressNameMap.size() > 1) {
             dialogAgent.outboundCallWithMap(addressNameMap, null, null, senderName, subject, url, null,
-                                            adapterConfig.getConfigId(), accountId, "");
+                                            adapterConfig.getConfigId(), accountId, "", adapterConfig.getAccountType());
         }
         else {
             dialogAgent.outboundCall(addressNameMap.keySet().iterator().next(), senderName, subject, url, null,
-                                     adapterConfig.getConfigId(), accountId, "");
+                                     adapterConfig.getConfigId(), accountId, "", adapterConfig.getAccountType());
         }
     }
 

--- a/dialoghandler/src/test/java/com/almende/dialog/adapter/TwilioAdapterIT.java
+++ b/dialoghandler/src/test/java/com/almende/dialog/adapter/TwilioAdapterIT.java
@@ -1209,9 +1209,8 @@ public class TwilioAdapterIT extends TestFramework {
         String callSid = UUID.randomUUID().toString();
         if (direction.equals("outbound")) {
             HashMap<String, String> outboundCall = dialogAgent.outboundCall(remoteAddressVoice, "test", null,
-                                                                            createDialog.getId(), null,
-                                                                            adapterConfig.getConfigId(),
-                                                                            TEST_PUBLIC_KEY, null);
+                createDialog.getId(), null, adapterConfig.getConfigId(), TEST_PUBLIC_KEY, null,
+                adapterConfig.getAccountType());
             String sessionKey = outboundCall.values().iterator().next();
             Session session = Session.getSession(sessionKey);
             callSid = session.getExternalSession();

--- a/dialoghandler/src/test/java/com/almende/dialog/adapter/VoiceXMLServletIT.java
+++ b/dialoghandler/src/test/java/com/almende/dialog/adapter/VoiceXMLServletIT.java
@@ -49,6 +49,7 @@ import com.almende.dialog.model.ddr.DDRRecord.CommunicationStatus;
 import com.almende.dialog.util.ServerUtils;
 import com.almende.util.jackson.JOM;
 import com.askfast.commons.RestResponse;
+import com.askfast.commons.entity.AccountType;
 import com.askfast.commons.entity.AdapterProviders;
 import com.askfast.commons.entity.AdapterType;
 import com.askfast.commons.entity.DDRType.DDRTypeCategory;
@@ -79,12 +80,11 @@ public class VoiceXMLServletIT extends TestFramework {
         new DDRRecordAgent().generateDefaultDDRTypes();
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
+            QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
         //create SMS adapter
         AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
-                                                          TEST_PUBLIC_KEY, localAddressBroadsoft,
-                                                          localFullAddressBroadsoft, url);
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, url);
 
         //create session
         Session session = Session.createSession(adapterConfig, remoteAddressVoice);
@@ -94,26 +94,26 @@ public class VoiceXMLServletIT extends TestFramework {
         Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
         VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
         Response newDialog = voiceXMLRESTProxy.getNewDialog("inbound", remoteAddressVoice, remoteAddressVoice,
-                                                            localFullAddressBroadsoft, null, uriInfo);
+            localFullAddressBroadsoft, null, uriInfo);
         HashMap<String, String> answerVariables = assertOpenQuestionWithDTMFType(newDialog.getEntity().toString());
 
         //answer the dialog
         Question retrivedQuestion = Question.fromURL(url, remoteAddressVoice, session);
         String mediaPropertyValue = retrivedQuestion.getMediaPropertyValue(MediumType.BROADSOFT,
-                                                                           MediaPropertyKey.RETRY_LIMIT);
+            MediaPropertyKey.RETRY_LIMIT);
 
         Integer retryCount = Question.getRetryCount(answerVariables.get("sessionKey"));
         int i = 0;
         while (i++ < 10) {
             Response answerResponse = voiceXMLRESTProxy.answer(answerVariables.get("questionId"), null,
-                                                               answerVariables.get("answerInput"),
-                                                               answerVariables.get("sessionKey"), null, uriInfo);
+                answerVariables.get("answerInput"), answerVariables.get("sessionKey"), null, uriInfo);
             if (answerResponse.getEntity() != null) {
                 if (answerResponse.getEntity()
                                   .toString()
-                                  .equals("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
-                                              + "<vxml version=\"2.1\" xmlns=\"http://www.w3.org/2001/vxml\">"
-                                              + "<form><block><exit/></block></form></vxml>")) {
+                                  .equals(
+                                      "<?xml version=\"1.0\" encoding=\"UTF-8\"?>"
+                                          + "<vxml version=\"2.1\" xmlns=\"http://www.w3.org/2001/vxml\">"
+                                          + "<form><block><exit/></block></form></vxml>")) {
                     break;
                 }
             }
@@ -130,21 +130,20 @@ public class VoiceXMLServletIT extends TestFramework {
         }
         //check all the ddrs created
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         assertEquals(ddrRecords.size(), 1);
         for (DDRRecord ddrRecord : ddrRecords) {
             assertEquals("inbound", ddrRecord.getDirection());
             assertEquals(adapterConfig.getFormattedMyAddress(), ddrRecord.getToAddress().keySet().iterator().next());
             assertEquals(PhoneNumberUtils.formatNumber(remoteAddressVoice, null), ddrRecord.getFromAddress());
             Object addressSessionKeyObject = ddrRecord.getAdditionalInfo().get(Session.SESSION_KEY);
-            Map<String, String> addressSessionKey = JOM.getInstance()
-                                                       .convertValue(addressSessionKeyObject,
-                                                                     new TypeReference<Map<String, String>>() {
-                                                                     });
+            Map<String, String> addressSessionKey = JOM.getInstance().convertValue(addressSessionKeyObject,
+                new TypeReference<Map<String, String>>() {
+                });
             assertEquals(PhoneNumberUtils.formatNumber(remoteAddressVoice, null), addressSessionKey.keySet().iterator()
                                                                                                    .next());
             assertEquals(ddrRecord.getSessionKeys().iterator().next(),
-                         addressSessionKey.get(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
+                addressSessionKey.get(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
         }
     }
 
@@ -157,12 +156,11 @@ public class VoiceXMLServletIT extends TestFramework {
     public void outboundPhoneCall_RepeatedBroadsoftSubsciptionFailTest() throws Exception {
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
+            QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
         //create SMS adapter
         AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
-                                                          TEST_PUBLIC_KEY, localAddressBroadsoft,
-                                                          localFullAddressBroadsoft, url);
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, url);
 
         //mock the Context
         UriInfo uriInfo = Mockito.mock(UriInfo.class);
@@ -170,12 +168,13 @@ public class VoiceXMLServletIT extends TestFramework {
 
         //used forcibly for Broadsoft.startCall() to throw an exception. 
         TestServlet.TEST_SERVLET_PATH += "test";
-        VoiceXMLRESTProxy.dial(remoteAddressVoice, url, adapterConfig, TEST_PUBLIC_KEY, null);
+        VoiceXMLRESTProxy.dial(remoteAddressVoice, url, adapterConfig, TEST_PUBLIC_KEY, null,
+            adapterConfig.getAccountType());
         List<DDRRecord> allDdrRecords = DDRRecord.getDDRRecords(null, null, null, null, null, null, null, null, null,
-                                                                null, null);
+            null, null);
         assertThat(allDdrRecords.isEmpty(), Matchers.is(true));
         Session session = Session.getSessionByInternalKey(adapterConfig.getAdapterType(), adapterConfig.getMyAddress(),
-                                                          PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
+            PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
         assertThat(session, Matchers.nullValue());
     }
 
@@ -189,26 +188,26 @@ public class VoiceXMLServletIT extends TestFramework {
     public void outboundPhoneCallMissingDDRTest() throws Exception {
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.OPEN_QUESTION.name());
+            QuestionInRequest.OPEN_QUESTION.name());
 
         url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
         //create SMS adapter
         AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
-                                                          TEST_PUBLIC_KEY, localAddressBroadsoft,
-                                                          localFullAddressBroadsoft, url);
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, url);
         adapterConfig.setXsiUser(localFullAddressBroadsoft);
         adapterConfig.setXsiSubscription(UUID.randomUUID().toString());
         adapterConfig.update();
 
         //setup some ddrPrices
         createTestDDRPrice(DDRTypeCategory.OUTGOING_COMMUNICATION_COST, 0.8, "Test outgoing", UnitType.SECOND, null,
-                           null);
+            null);
 
         //trigger an outbound call
-        VoiceXMLRESTProxy.dial(remoteAddressVoice, url, adapterConfig, adapterConfig.getOwner(), null);
+        VoiceXMLRESTProxy.dial(remoteAddressVoice, url, adapterConfig, adapterConfig.getOwner(), null,
+            adapterConfig.getAccountType());
         //fetch the session, assert that a ddrRecord is not attached still
         Session session = Session.getSessionByInternalKey(AdapterAgent.ADAPTER_TYPE_CALL, localFullAddressBroadsoft,
-                                                          PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
+            PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
         assertThat(session, notNullValue());
         assertThat(session.getDdrRecordId(), Matchers.notNullValue());
 
@@ -218,7 +217,7 @@ public class VoiceXMLServletIT extends TestFramework {
         //mimick a fetch new dialog/ phone pickup
         VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
         Response newDialog = voiceXMLRESTProxy.getNewDialog("outbound", remoteAddressVoice, remoteAddressVoice,
-                                                            localFullAddressBroadsoft, null, uriInfo);
+            localFullAddressBroadsoft, null, uriInfo);
         assertOpenQuestionWithDTMFType(newDialog.getEntity().toString());
         //a ddr must be attached to hte session
         session = Session.getSession(session.getKey());
@@ -247,8 +246,8 @@ public class VoiceXMLServletIT extends TestFramework {
         //check that the ddr addres status is switched to RECEIVED
         DDRRecord ddrRecord = DDRRecord.getDDRRecord(session.getDdrRecordId(), session.getAccountId());
         assertEquals(CommunicationStatus.RECEIVED,
-                     ddrRecord.getStatusForAddress(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
-        
+            ddrRecord.getStatusForAddress(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
+
         String hangupXML = "<?xml version=\"1.0\" encoding=\"UTF-8\"?><Event xmlns=\"http://schema.broadsoft.com/xsi-events\" " +
             "xmlns:xsi1=\"http://www.w3.org/2001/XMLSchema-instance\"><sequenceNumber>257</sequenceNumber><subscriberId>" +
             localFullAddressBroadsoft +
@@ -273,7 +272,7 @@ public class VoiceXMLServletIT extends TestFramework {
         assertThat(ddrRecord.getStart(), Matchers.is(1401809070192L));
         //check that the ddr addres status is switched to FINISHED
         assertEquals(CommunicationStatus.FINISHED,
-                     ddrRecord.getStatusForAddress(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
+            ddrRecord.getStatusForAddress(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
     }
 
     /**
@@ -290,14 +289,14 @@ public class VoiceXMLServletIT extends TestFramework {
         outboundPhoneCallMissingDDRTest();
         //fetch all the ddrRecords
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         //make sure that all the logs belong to atleast one ddrRecord
         //        int logsCount = 0;
         long startTimestamp = TimeUtils.getServerCurrentTimeInMillis();
         boolean isDDRLogFound = false;
         for (DDRRecord ddrRecord : ddrRecords) {
             List<Log> logsForDDRRecord = Logger.find(TEST_PUBLIC_KEY, ddrRecord.getId(), null, null, null, null, null,
-                                                     null);
+                null);
             for (Log log : logsForDDRRecord) {
                 assertThat(log.getAccountId(), Matchers.is(ddrRecord.getAccountId()));
                 assertThat(log.getAccountId(), Matchers.notNullValue());
@@ -331,14 +330,14 @@ public class VoiceXMLServletIT extends TestFramework {
         outboundPhoneCallMissingDDRTest();
         //fetch all the ddrRecords
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         //make sure that all the logs belong to atleast one ddrRecord
         //        int logsCount = 0;
         long startTimestamp = TimeUtils.getServerCurrentTimeInMillis();
         boolean isDDRLogFound = false;
         for (DDRRecord ddrRecord : ddrRecords) {
             List<Log> logsForDDRRecord = Logger.find(TEST_PUBLIC_KEY, ddrRecord.getId(), null, null, null, null, null,
-                                                     null);
+                null);
             for (Log log : logsForDDRRecord) {
                 assertThat(log.getAccountId(), Matchers.is(ddrRecord.getAccountId()));
                 assertThat(log.getAccountId(), Matchers.notNullValue());
@@ -369,13 +368,12 @@ public class VoiceXMLServletIT extends TestFramework {
         Mockito.when(dialogAgent.getGlobalProviderCredentials()).thenReturn(null);
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.OPEN_QUESTION.name());
+            QuestionInRequest.OPEN_QUESTION.name());
 
         url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
         //create SMS adapter
         AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
-                                                          TEST_PUBLIC_KEY, localAddressBroadsoft,
-                                                          localFullAddressBroadsoft, url);
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, url);
         adapterConfig.setXsiUser(localFullAddressBroadsoft);
         adapterConfig.setXsiSubscription(TEST_PUBLIC_KEY);
         adapterConfig.update();
@@ -383,12 +381,11 @@ public class VoiceXMLServletIT extends TestFramework {
         //perform an outbound call
         HashMap<String, String> addressMap = new HashMap<String, String>();
         addressMap.put(remoteAddressVoice, "");
-        Mockito.when(dialogAgent.outboundCallWithMap(addressMap, null, null, null, null, url, null,
-                                                     adapterConfig.getConfigId(), adapterConfig.getOwner(), ""))
-               .thenCallRealMethod();
+        Mockito.when(
+            dialogAgent.outboundCallWithMap(addressMap, null, null, null, null, url, null, adapterConfig.getConfigId(),
+                adapterConfig.getOwner(), "", adapterConfig.getAccountType())).thenCallRealMethod();
         HashMap<String, String> result = dialogAgent.outboundCallWithMap(addressMap, null, null, null, null, url, null,
-                                                                         adapterConfig.getConfigId(),
-                                                                         adapterConfig.getOwner(), "");
+            adapterConfig.getConfigId(), adapterConfig.getOwner(), "", adapterConfig.getAccountType());
         assertTrue(result != null);
         assertTrue(result.get(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)) != null);
         Session.drop(result.get(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
@@ -410,14 +407,14 @@ public class VoiceXMLServletIT extends TestFramework {
         //mock the Context
         Mockito.when(dialogAgent.getGlobalProviderCredentials()).thenReturn(globalAdapterCredentials);
         //switch calling adapter globally
-        Mockito.when(dialogAgent.getGlobalAdapterSwitchSettingsForType(AdapterType.CALL))
-               .thenReturn(AdapterProviders.TWILIO);
+        Mockito.when(dialogAgent.getGlobalAdapterSwitchSettingsForType(AdapterType.CALL)).thenReturn(
+            AdapterProviders.TWILIO);
         Mockito.when(dialogAgent.getApplicationId()).thenReturn(UUID.randomUUID().toString());
 
         //initiate outbound request again
 
         result = dialogAgent.outboundCallWithMap(addressMap, null, null, null, null, url, null,
-                                                 adapterConfig.getConfigId(), adapterConfig.getOwner(), "");
+            adapterConfig.getConfigId(), adapterConfig.getOwner(), "", adapterConfig.getAccountType());
         assertTrue(result != null);
         assertTrue(result.get(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)) != null);
         Session session = Session.getSession(result.get(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
@@ -441,7 +438,7 @@ public class VoiceXMLServletIT extends TestFramework {
 
         //fetch the session
         Session session = Session.getSessionByInternalKey(AdapterAgent.ADAPTER_TYPE_CALL, localFullAddressBroadsoft,
-                                                          PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
+            PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
         //add a specific adapter switch
         String testMyAddress = "0854881002";
         Map<AdapterProviders, Map<String, AdapterConfig>> globalSwitchProviderCredentials = dialogAgent.getGlobalProviderCredentials();
@@ -460,14 +457,13 @@ public class VoiceXMLServletIT extends TestFramework {
 
         //initiate outbound request again
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.OPEN_QUESTION.name());
+            QuestionInRequest.OPEN_QUESTION.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
 
         HashMap<String, String> addressMap = new HashMap<String, String>();
         addressMap.put(remoteAddressVoice, "");
         HashMap<String, String> result = dialogAgent.outboundCallWithMap(addressMap, null, null, null, null, url, null,
-                                                                         session.getAdapterID(),
-                                                                         session.getAdapterConfig().getOwner(), "");
+            session.getAdapterID(), session.getAdapterConfig().getOwner(), "", session.getAccountType());
         assertTrue(result != null);
         assertTrue(result.get(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)) != null);
         session = Session.getSession(result.get(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
@@ -476,7 +472,7 @@ public class VoiceXMLServletIT extends TestFramework {
         assertThat(session.getLocalAddress(), Matchers.is(localFullAddressBroadsoft));
         assertEquals(AdapterType.CALL.toString().toLowerCase(), session.getType().toLowerCase());
         assertEquals(AdapterProviders.TWILIO.toString().toLowerCase(),
-                     session.getAllExtras().get(AdapterConfig.ADAPTER_PROVIDER_KEY).toString().toLowerCase());
+            session.getAllExtras().get(AdapterConfig.ADAPTER_PROVIDER_KEY).toString().toLowerCase());
     }
 
     /**
@@ -487,40 +483,39 @@ public class VoiceXMLServletIT extends TestFramework {
     public void eventCallBackPayloadTest() throws Exception {
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.OPEN_QUESTION.name());
+            QuestionInRequest.OPEN_QUESTION.name());
 
         url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
         //create SMS adapter
         AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
-                                                          TEST_PUBLIC_KEY, localAddressBroadsoft,
-                                                          localFullAddressBroadsoft, url);
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, url);
         adapterConfig.setXsiUser(localFullAddressBroadsoft);
         adapterConfig.setXsiSubscription(TEST_PUBLIC_KEY);
         adapterConfig.update();
 
         //trigger an outbound call
         String sessionKey1 = VoiceXMLRESTProxy.dial(remoteAddressVoice, url, adapterConfig, adapterConfig.getOwner(),
-                                                    null);
+            null, adapterConfig.getAccountType());
         VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
         voiceXMLRESTProxy.timeout(UUID.randomUUID().toString(), sessionKey1, null);
 
         //validate that the session has it
         Session session = Session.getSession(sessionKey1);
         assertThat(session.getAllExtras().get(AdapterConfig.ADAPTER_PROVIDER_KEY),
-                   Matchers.is(AdapterProviders.BROADSOFT.toString()));
+            Matchers.is(AdapterProviders.BROADSOFT.toString()));
 
         //mock the Context
         UriInfo uriInfo = Mockito.mock(UriInfo.class);
         Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
         //mimick a fetch new dialog/ phone pickup
         String sessionKey2 = VoiceXMLRESTProxy.dial(remoteAddressVoice, url, adapterConfig, adapterConfig.getOwner(),
-                                                    null);
+            null, adapterConfig.getAccountType());
         voiceXMLRESTProxy.answer(UUID.randomUUID().toString(), null, "1", sessionKey2, null, uriInfo);
 
         //validate that the session has it
         session = Session.getSession(sessionKey2);
         assertThat(session.getAllExtras().get(AdapterConfig.ADAPTER_PROVIDER_KEY),
-                   Matchers.is(AdapterProviders.BROADSOFT.toString()));
+            Matchers.is(AdapterProviders.BROADSOFT.toString()));
     }
 
     /**
@@ -582,7 +577,7 @@ public class VoiceXMLServletIT extends TestFramework {
         assertTrue(securedDialogResponse != null);
         assertOpenQuestionWithDTMFType(securedDialogResponse.getEntity().toString());
     }
-    
+
     /**
      * This test is to check if the inbound functionality works for a dialog
      * with the right credentials for the secured url access, but no ddr records
@@ -595,29 +590,29 @@ public class VoiceXMLServletIT extends TestFramework {
 
         new DDRRecordAgent().generateDefaultDDRTypes();
         createTestDDRPrice(DDRTypeCategory.INCOMING_COMMUNICATION_COST, 0.1, "Test incoming costs", UnitType.MINUTE,
-                           null, null);
+            null, null);
         Response securedDialogResponse = performSecuredInboundCall("testuserName", "testpassword", null, null, false);
         assertTrue(securedDialogResponse != null);
         assertOpenQuestionWithDTMFType(securedDialogResponse.getEntity().toString());
 
         //validate that ddr records are created when isTest is set to false
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         Assert.assertThat(ddrRecords.size(), Matchers.equalTo(1));
-        
+
         //trigger a second incoming call with test flag to be true. flush all sessions, adapters and ddrRecords
         setup();
-        
+
         new DDRRecordAgent().generateDefaultDDRTypes();
         createTestDDRPrice(DDRTypeCategory.INCOMING_COMMUNICATION_COST, 0.1, "Test incoming costs", UnitType.MINUTE,
-                           null, null);
+            null, null);
         securedDialogResponse = performSecuredInboundCall("testuserName", "testpassword", null, null, true);
         assertTrue(securedDialogResponse != null);
         assertOpenQuestionWithDTMFType(securedDialogResponse.getEntity().toString());
 
         //validate that ddr records are created when isTest is set to false
         ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null, null, null,
-                                             null);
+            null);
         Assert.assertThat(ddrRecords.size(), Matchers.equalTo(0));
     }
 
@@ -631,7 +626,7 @@ public class VoiceXMLServletIT extends TestFramework {
     public void outboundPhoneCall_WithSecuredDialogAccessFailTest() throws Exception {
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
+            QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
         url = ServerUtils.getURLWithQueryParams(url, "secured", "true");
         Dialog dialog = Dialog.createDialog("Test secured dialog", url, TEST_PUBLIC_KEY);
@@ -666,7 +661,7 @@ public class VoiceXMLServletIT extends TestFramework {
         ttsInfo.setVoiceUsed("testtest");
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.SIMPLE_COMMENT.name());
+            QuestionInRequest.SIMPLE_COMMENT.name());
         String message = "How are you doing? today";
         url = ServerUtils.getURLWithQueryParams(url, "question", message);
         Response securedDialogResponse = performSecuredInboundCall("testuserName", "testpassword", ttsInfo, url, null);
@@ -738,9 +733,9 @@ public class VoiceXMLServletIT extends TestFramework {
 
         DDRRecordAgent ddrRecordAgent = new DDRRecordAgent();
         ddrRecordAgent.createDDRPriceWithNewDDRType("TTS service costs", DDRTypeCategory.TTS_SERVICE_COST.name(), null,
-                                                    null, 0.01, null, null, null, null, null, null, null);
+            null, 0.01, null, null, null, null, null, null, null);
         ddrRecordAgent.createDDRPriceWithNewDDRType("TTS service costs", DDRTypeCategory.TTS_COST.name(), null, null,
-                                                    0.01, null, null, null, null, null, null, null);
+            0.01, null, null, null, null, null, null, null);
 
         String ttsAccountId = UUID.randomUUID().toString();
         TTSInfo ttsInfo = new TTSInfo();
@@ -749,7 +744,7 @@ public class VoiceXMLServletIT extends TestFramework {
         ttsInfo.setTtsAccountId(ttsAccountId);
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.SIMPLE_COMMENT.name());
+            QuestionInRequest.SIMPLE_COMMENT.name());
         String message = "How are you doing? today";
         url = ServerUtils.getURLWithQueryParams(url, "question", message);
         String securedDialogResponse = null;
@@ -769,12 +764,12 @@ public class VoiceXMLServletIT extends TestFramework {
             UriInfo uriInfo = Mockito.mock(UriInfo.class);
             Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
             new VoiceXMLRESTProxy().getNewDialog("outbound", remoteAddressVoice, remoteAddressVoice,
-                                                 localFullAddressBroadsoft, null, uriInfo);
+                localFullAddressBroadsoft, null, uriInfo);
         }
         assertTrue(securedDialogResponse != null);
         //check if ddr is created for ttsprocessing
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         int ttsServiceChargesAttached = 0;
         for (DDRRecord ddrRecord : ddrRecords) {
             Assert.assertFalse(ddrRecord.getDdrType().getCategory().equals(DDRTypeCategory.TTS_COST));
@@ -791,7 +786,7 @@ public class VoiceXMLServletIT extends TestFramework {
         new DDRRecordAgent().generateDefaultDDRTypes();
         String invalidNumber = "+3161234567";
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.REFERRAL.name());
+            QuestionInRequest.REFERRAL.name());
         url = ServerUtils.getURLWithQueryParams(url, "address", invalidNumber); //invalid address
         url = ServerUtils.getURLWithQueryParams(url, "question", "Hello...");
 
@@ -804,12 +799,12 @@ public class VoiceXMLServletIT extends TestFramework {
         Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
         VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
         Response newDialog = voiceXMLRESTProxy.getNewDialog("outbound", remoteAddressVoice, remoteAddressVoice,
-                                                            localFullAddressBroadsoft, null, uriInfo);
+            localFullAddressBroadsoft, null, uriInfo);
         assertThat(newDialog.getEntity().toString(), Matchers.not(Matchers.containsString(invalidNumber)));
         List<Session> allSessions = Session.getAllSessions();
         assertThat(allSessions.size(), Matchers.is(0));
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         assertThat(ddrRecords.size(), Matchers.is(1));
         int ddrInfoCount = 0;
         DDRRecord ddrRecord = ddrRecords.iterator().next();
@@ -821,7 +816,7 @@ public class VoiceXMLServletIT extends TestFramework {
         }
         assertThat(ddrInfoCount, Matchers.is(1));
     }
-    
+
     /**
      * Test to check if the ddr records are linked when a referral is triggered
      * 
@@ -833,7 +828,7 @@ public class VoiceXMLServletIT extends TestFramework {
         String referralNumber = "0611111111";
         new DDRRecordAgent().generateDefaultDDRTypes();
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.REFERRAL.name());
+            QuestionInRequest.REFERRAL.name());
         url = ServerUtils.getURLWithQueryParams(url, "address", referralNumber);
         url = ServerUtils.getURLWithQueryParams(url, "question", "Hello...");
 
@@ -873,23 +868,23 @@ public class VoiceXMLServletIT extends TestFramework {
 
         DDRRecordAgent ddrRecordAgent = new DDRRecordAgent();
         ddrRecordAgent.createDDRPriceWithNewDDRType("TTS service costs", DDRTypeCategory.TTS_SERVICE_COST.name(), null,
-                                                    null, 0.01, null, null, null, null, null, null, null);
+            null, 0.01, null, null, null, null, null, null, null);
         ddrRecordAgent.createDDRPriceWithNewDDRType("TTS service costs", DDRTypeCategory.TTS_COST.name(), null, null,
-                                                    0.01, null, null, null, null, null, null, null);
+            0.01, null, null, null, null, null, null, null);
 
         TTSInfo ttsInfo = new TTSInfo();
         ttsInfo.setProvider(TTSProvider.ACAPELA);
         ttsInfo.setVoiceUsed("testtest");
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.SIMPLE_COMMENT.name());
+            QuestionInRequest.SIMPLE_COMMENT.name());
         String message = "How are you doing? today";
         url = ServerUtils.getURLWithQueryParams(url, "question", message);
         Response securedDialogResponse = performSecuredInboundCall("testuserName", "testpassword", ttsInfo, url, null);
         assertTrue(securedDialogResponse != null);
         //check if ddr is created for ttsprocessing
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         int ttsChargesAttached = 0;
         for (DDRRecord ddrRecord : ddrRecords) {
             Assert.assertFalse(ddrRecord.getDdrType().getCategory().equals(DDRTypeCategory.TTS_SERVICE_COST));
@@ -923,7 +918,7 @@ public class VoiceXMLServletIT extends TestFramework {
     public void outboundPhoneCall_WithSecuredDialogAccessSuccessTest() throws Exception {
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
+            QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
         url = ServerUtils.getURLWithQueryParams(url, "secured", "true");
         Dialog dialog = Dialog.createDialog("Test secured dialog", url, TEST_PUBLIC_KEY);
@@ -946,7 +941,7 @@ public class VoiceXMLServletIT extends TestFramework {
     public void inboundCallWithWrongOrderDtmfTest() throws Exception {
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.APPOINTMENT.name());
+            QuestionInRequest.APPOINTMENT.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", "start");
         url = ServerUtils.getURLWithQueryParams(url, "byDtmf", "true");
         url = ServerUtils.getURLWithQueryParams(url, "yesDtmf", "3");
@@ -963,18 +958,17 @@ public class VoiceXMLServletIT extends TestFramework {
         Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
         VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
         voiceXMLRESTProxy.getNewDialog("inbound", remoteAddressVoice, remoteAddressVoice, localFullAddressBroadsoft,
-                                       null, uriInfo);
+            null, uriInfo);
 
         //fetch current sesison
         Session session = Session.getSessionByInternalKey(adapterConfig.getAdapterType(), adapterConfig.getMyAddress(),
-                                                          PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
+            PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
         assertNotNull(session);
         //trigger answer 
         Response answer = voiceXMLRESTProxy.answer("1", null, "1", session.getKey(), null, uriInfo);
-        assertTrue(String.format("%s doesnt contain %s", answer.getEntity().toString(),
-                                 TestServlet.APPOINTMENT_MAIN_QUESTION),
-                   answer.getEntity().toString()
-                         .contains(URLEncoder.encode(TestServlet.APPOINTMENT_MAIN_QUESTION, "UTF-8")));
+        assertTrue(
+            String.format("%s doesnt contain %s", answer.getEntity().toString(), TestServlet.APPOINTMENT_MAIN_QUESTION),
+            answer.getEntity().toString().contains(URLEncoder.encode(TestServlet.APPOINTMENT_MAIN_QUESTION, "UTF-8")));
     }
 
     /**
@@ -1036,25 +1030,26 @@ public class VoiceXMLServletIT extends TestFramework {
      * Test if the
      * {@link DialogAgent#outboundCallWithDialogRequest(com.askfast.commons.entity.DialogRequest)}
      * gives an error code if the question is not fetched by the dialog agent
-     * @throws UnsupportedEncodingException 
+     * 
+     * @throws UnsupportedEncodingException
      */
     @Test
     public void outboundCallWithoutQuestionTest() throws Exception {
-        
+
         dialogAgent = new DialogAgent();
         //setup bad question url
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH + "wrongURL", "questionType",
-                                                       QuestionInRequest.TWELVE_INPUT.name());
+            QuestionInRequest.TWELVE_INPUT.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", "start");
-        
+
         //create mail adapter
         AdapterConfig adapterConfig = createBroadsoftAdapter();
-        
+
         //setup to generate ddrRecords
         new DDRRecordAgent().generateDefaultDDRTypes();
         createTestDDRPrice(DDRTypeCategory.OUTGOING_COMMUNICATION_COST, 0.1, "test", UnitType.SECOND, AdapterType.CALL,
-                           null);
-        
+            null);
+
         DialogRequest details = new DialogRequest();
         details.setAccountID(adapterConfig.getOwner());
         details.setAdapterID(adapterConfig.getConfigId());
@@ -1065,18 +1060,17 @@ public class VoiceXMLServletIT extends TestFramework {
         RestResponse outboundCallResponse = dialogAgent.outboundCallWithDialogRequest(details);
         assertEquals(Status.BAD_REQUEST.getStatusCode(), outboundCallResponse.getCode());
         assertThat(outboundCallResponse.getMessage(), Matchers.is(DialogAgent.getQuestionNotFetchedMessage(url)));
-        
+
         //verify that the session is not saved
         assertEquals(0, Session.getAllSessions().size());
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         assertEquals(1, ddrRecords.size());
         assertEquals(CommunicationStatus.ERROR,
-                     ddrRecords.iterator().next()
-                               .getStatusForAddress(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
+            ddrRecords.iterator().next().getStatusForAddress(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
         assertEquals(1, ddrRecords.iterator().next().getStatusPerAddress().size());
     }
-    
+
     /**
      * Test if the
      * {@link DialogAgent#outboundCallWithDialogRequest(com.askfast.commons.entity.DialogRequest)}
@@ -1091,7 +1085,7 @@ public class VoiceXMLServletIT extends TestFramework {
         dialogAgent = new DialogAgent();
         //setup bad question url
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.TWELVE_INPUT.name());
+            QuestionInRequest.TWELVE_INPUT.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", "start");
 
         //create mail adapter
@@ -1100,7 +1094,7 @@ public class VoiceXMLServletIT extends TestFramework {
         //setup to generate ddrRecords
         new DDRRecordAgent().generateDefaultDDRTypes();
         createTestDDRPrice(DDRTypeCategory.OUTGOING_COMMUNICATION_COST, 0.1, "test", UnitType.SECOND, AdapterType.CALL,
-                           null);
+            null);
 
         DialogRequest details = new DialogRequest();
         details.setAccountID(adapterConfig.getOwner());
@@ -1114,17 +1108,17 @@ public class VoiceXMLServletIT extends TestFramework {
         //verify that the session is not saved
         assertEquals(1, Session.getAllSessions().size());
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         assertEquals(1, ddrRecords.size());
         DDRRecord ddrRecord = ddrRecords.iterator().next();
         assertEquals(CommunicationStatus.ERROR,
-                     ddrRecord.getStatusForAddress(PhoneNumberUtils.formatNumber("0611223", null)));
+            ddrRecord.getStatusForAddress(PhoneNumberUtils.formatNumber("0611223", null)));
         assertEquals(CommunicationStatus.SENT,
-                     ddrRecord.getStatusForAddress(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
+            ddrRecord.getStatusForAddress(PhoneNumberUtils.formatNumber(remoteAddressVoice, null)));
         assertEquals(2, ddrRecords.iterator().next().getStatusPerAddress().size());
-        
+
     }
-    
+
     /**
      * Test if the
      * {@link DialogAgent#outboundCallWithDialogRequest(com.askfast.commons.entity.DialogRequest)}
@@ -1139,7 +1133,7 @@ public class VoiceXMLServletIT extends TestFramework {
         dialogAgent = new DialogAgent();
         //setup bad question url
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.TWELVE_INPUT.name());
+            QuestionInRequest.TWELVE_INPUT.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", "start");
 
         //create mail adapter
@@ -1148,7 +1142,7 @@ public class VoiceXMLServletIT extends TestFramework {
         //setup to generate ddrRecords
         new DDRRecordAgent().generateDefaultDDRTypes();
         createTestDDRPrice(DDRTypeCategory.OUTGOING_COMMUNICATION_COST, 0.1, "test", UnitType.SECOND, AdapterType.CALL,
-                           null);
+            null);
 
         DialogRequest details = new DialogRequest();
         details.setAccountID(adapterConfig.getOwner());
@@ -1162,13 +1156,100 @@ public class VoiceXMLServletIT extends TestFramework {
         //verify that the session is not saved
         assertEquals(0, Session.getAllSessions().size());
         List<DDRRecord> ddrRecords = DDRRecord.getDDRRecords(TEST_PUBLIC_KEY, null, null, null, null, null, null, null,
-                                                             null, null, null);
+            null, null, null);
         assertEquals(1, ddrRecords.size());
         assertEquals(CommunicationStatus.ERROR,
-                     ddrRecords.iterator().next().getStatusForAddress(PhoneNumberUtils.formatNumber("0611223", null)));
+            ddrRecords.iterator().next().getStatusForAddress(PhoneNumberUtils.formatNumber("0611223", null)));
         assertEquals(1, ddrRecords.iterator().next().getStatusPerAddress().size());
         //no session must be created
         assertEquals(0, Session.getAllSessions().size());
+    }
+
+    /**
+     * check if a trial message is played when an outbound call is initiated
+     * from a trial account sharing an adapter with POST PAID type owner
+     * account.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void trialMessagePlayedWithSharingPostPaidAccountOutBoundTest() throws Exception {
+
+        String sharedAccountId = UUID.randomUUID().toString();
+
+        //create POST PAID CALL adapter
+        AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, null);
+        adapterConfig.setAccountType(AccountType.POST_PAID);
+        adapterConfig.addAccount(sharedAccountId);
+        adapterConfig.update();
+
+        String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
+            QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
+        url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
+
+        //trigger an outbound call
+        String sessionKey = VoiceXMLRESTProxy.dial(remoteAddressVoice, url, adapterConfig, sharedAccountId, null,
+            AccountType.TRIAL);
+        //process the call
+        UriInfo uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
+        VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
+        Response dialogResponse = voiceXMLRESTProxy.getNewDialog("outbound", remoteAddressVoice, remoteAddressVoice,
+            localFullAddressBroadsoft, null, uriInfo);
+
+        //check the dialogResponse. This must have a link to the trial audio
+        Assert.assertThat(dialogResponse.getEntity().toString(), Matchers.containsString(String.format(
+            "<audio src=\"http://localhost:%s/dialoghandler/en_trial_message.wav\"/>", jettyPort)));
+
+        //check the session and validate the question for the trial audio
+        Session session = Session.getSession(sessionKey);
+        Assert.assertThat(session.getAccountType(), Matchers.is(AccountType.TRIAL));
+    }
+
+    /**
+     * check if a trial message is not played when an inbound call is initiated from
+     * a trial account sharing an adapter with POST PAID type owner account.
+     * 
+     * @throws Exception
+     */
+    @Test
+    public void trialMessageNotPlayedWithSharingPostPaidAccountInboundTest() throws Exception {
+
+        String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
+            QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
+        url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
+        
+        //create a dialog
+        dialogAgent = dialogAgent != null ? dialogAgent : new DialogAgent();
+        dialogAgent.createDialog(TEST_PUBLIC_KEY, "Test secured dialog", url);
+        Dialog dialog = Dialog.createDialog("Test secured dialog", url, TEST_PUBLIC_KEY);
+        dialog.storeOrUpdate();
+        
+        String sharedAccountId = UUID.randomUUID().toString();
+        //create POST PAID CALL adapter
+        AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, null);
+        adapterConfig.setAccountType(AccountType.POST_PAID);
+        adapterConfig.addAccount(sharedAccountId);
+        adapterConfig.setDialogId(dialog.getId());
+        adapterConfig.update();
+
+        //trigger inbound call
+        UriInfo uriInfo = Mockito.mock(UriInfo.class);
+        Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
+        VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
+        Response dialogResponse = voiceXMLRESTProxy.getNewDialog("inbound", remoteAddressVoice, remoteAddressVoice,
+            localFullAddressBroadsoft, null, uriInfo);
+
+        //check the dialogResponse. This must have a link to the trial audio
+        Assert.assertThat(dialogResponse.getEntity().toString(),
+            Matchers.not(Matchers.containsString(String.format("trial_message\"/>", jettyPort))));
+
+        //check the session and validate the question for the trial audio
+        Session session = Session.getSessionByInternalKey("call", localFullAddressBroadsoft,
+            PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
+        Assert.assertThat(session.getAccountType(), Matchers.not(AccountType.TRIAL));
     }
 
     /**
@@ -1181,7 +1262,7 @@ public class VoiceXMLServletIT extends TestFramework {
     private void inboundCallWithDTMFAsAnswerTest(String answerDtmf) throws Exception {
 
         String url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                       QuestionInRequest.TWELVE_INPUT.name());
+            QuestionInRequest.TWELVE_INPUT.name());
         url = ServerUtils.getURLWithQueryParams(url, "question", "start");
         Dialog dialog = Dialog.createDialog("Test dialog", url, TEST_PUBLIC_KEY);
 
@@ -1195,16 +1276,16 @@ public class VoiceXMLServletIT extends TestFramework {
         Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
         VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
         voiceXMLRESTProxy.getNewDialog("inbound", remoteAddressVoice, remoteAddressVoice, localFullAddressBroadsoft,
-                                       null, uriInfo);
+            null, uriInfo);
 
         //fetch current sesison
         Session session = Session.getSessionByInternalKey(adapterConfig.getAdapterType(), adapterConfig.getMyAddress(),
-                                                          PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
+            PhoneNumberUtils.formatNumber(remoteAddressVoice, null));
         assertNotNull(session);
         //trigger answer 
         Response answer = voiceXMLRESTProxy.answer(answerDtmf, null, answerDtmf, session.getKey(), null, uriInfo);
         assertTrue(String.format("%s doesnt contain %s", answer.getEntity().toString(), "You pressed: " + answerDtmf),
-                   answer.getEntity().toString().contains(URLEncoder.encode("You pressed: " + answerDtmf, "UTF-8")));
+            answer.getEntity().toString().contains(URLEncoder.encode("You pressed: " + answerDtmf, "UTF-8")));
     }
 
     /**
@@ -1217,7 +1298,7 @@ public class VoiceXMLServletIT extends TestFramework {
 
         if (url == null) {
             url = ServerUtils.getURLWithQueryParams(TestServlet.TEST_SERVLET_PATH, "questionType",
-                                                    QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
+                QuestionInRequest.OPEN_QUESION_WITHOUT_ANSWERS.name());
             url = ServerUtils.getURLWithQueryParams(url, "question", COMMENT_QUESTION_AUDIO);
             url = ServerUtils.getURLWithQueryParams(url, "secured", "true");
         }
@@ -1234,8 +1315,7 @@ public class VoiceXMLServletIT extends TestFramework {
 
         //create SMS adapter
         AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
-                                                          TEST_PUBLIC_KEY, localAddressBroadsoft,
-                                                          localFullAddressBroadsoft, url);
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, url);
         adapterConfig.setDialogId(createDialog.getId());
         adapterConfig.update();
 
@@ -1244,7 +1324,7 @@ public class VoiceXMLServletIT extends TestFramework {
         Mockito.when(uriInfo.getBaseUri()).thenReturn(new URI(TestServlet.TEST_SERVLET_PATH));
         VoiceXMLRESTProxy voiceXMLRESTProxy = new VoiceXMLRESTProxy();
         return voiceXMLRESTProxy.getNewDialog("inbound", remoteAddressVoice, remoteAddressVoice,
-                                              localFullAddressBroadsoft, isTest, uriInfo);
+            localFullAddressBroadsoft, isTest, uriInfo);
     }
 
     /**
@@ -1257,12 +1337,12 @@ public class VoiceXMLServletIT extends TestFramework {
 
         //create a dialog
         dialogAgent = dialogAgent != null ? dialogAgent : new DialogAgent();
-        //create SMS adapter
+        //create CALL adapter
         AdapterConfig adapterConfig = createAdapterConfig(AdapterAgent.ADAPTER_TYPE_CALL, AdapterProviders.BROADSOFT,
-                                                          TEST_PUBLIC_KEY, localAddressBroadsoft,
-                                                          localFullAddressBroadsoft, null);
+            TEST_PUBLIC_KEY, localAddressBroadsoft, localFullAddressBroadsoft, null);
         //trigger an outbound call
-        return VoiceXMLRESTProxy.dial(remoteAddressVoice, dialog.getId(), adapterConfig, adapterConfig.getOwner(), null);
+        return VoiceXMLRESTProxy.dial(remoteAddressVoice, dialog.getId(), adapterConfig, adapterConfig.getOwner(),
+            null, adapterConfig.getAccountType());
     }
 
     /**

--- a/dialoghandler/src/test/java/com/almende/dialog/agent/DDRRecordAgentIT.java
+++ b/dialoghandler/src/test/java/com/almende/dialog/agent/DDRRecordAgentIT.java
@@ -154,7 +154,7 @@ public class DDRRecordAgentIT extends TestFramework {
         }
         assertThat(assertCount, Matchers.is(2));
     }
-
+    
     /**
      * check if a ddr is created but only service costs are attached for a
      * PRIVATE trial account adapter.
@@ -605,41 +605,38 @@ public class DDRRecordAgentIT extends TestFramework {
                 updateAdapterAsPrivate(isPrivate, adapterConfig);
                 //check if a ddr record is created by sending an outbound email
                 new MBSmsServlet().startDialog(addressNameMap, null, null, message, "Test Customer", "Test subject",
-                                               adapterConfig, adapterConfig.getOwner());
+                    adapterConfig, adapterConfig.getOwner(), type);
                 break;
             case EMAIL:
                 adapterId = adapterAgent.createEmailAdapter(MailServlet.DEFAULT_SENDER_EMAIL,
-                                                            MailServlet.DEFAULT_SENDER_EMAIL_PASSWORD, "Test", null,
-                                                            null, null, null, null, null, TEST_ACCOUNTID, null, null,
-                                                            null);
+                    MailServlet.DEFAULT_SENDER_EMAIL_PASSWORD, "Test", null, null, null, null, null, null,
+                    TEST_ACCOUNTID, null, type.toString(), null);
                 adapterConfig = AdapterConfig.getAdapterConfig(adapterId);
                 adapterConfig.setAccountType(type);
                 updateAdapterAsPrivate(isPrivate, adapterConfig);
                 new MailServlet().startDialog(addressNameMap, null, null, message, "Test Customer", "Test subject",
-                                              adapterConfig, adapterConfig.getOwner());
+                    adapterConfig, adapterConfig.getOwner(), type);
                 break;
             case XMPP:
                 adapterId = adapterAgent.createXMPPAdapter(MailServlet.DEFAULT_SENDER_EMAIL,
-                                                           MailServlet.DEFAULT_SENDER_EMAIL_PASSWORD, "test", null,
-                                                           null, null, null, TEST_ACCOUNTID, null, null, null);
+                    MailServlet.DEFAULT_SENDER_EMAIL_PASSWORD, "test", null, null, null, null, TEST_ACCOUNTID, null,
+                    type.toString(), null);
                 adapterConfig = AdapterConfig.getAdapterConfig(adapterId);
                 adapterConfig.setAccountType(type);
                 updateAdapterAsPrivate(isPrivate, adapterConfig);
                 new XMPPServlet().startDialog(addressNameMap, null, null, message, "Test Customer", "Test subject",
-                                              adapterConfig, adapterConfig.getOwner());
+                    adapterConfig, adapterConfig.getOwner(), type);
                 break;
             case CALL:
                 RestResponse createBroadSoftAdapter = adapterAgent.createBroadSoftAdapter(localFullAddressBroadsoft,
-                                                                                          "askask", null,
-                                                                                          TEST_ACCOUNTID, false, null,
-                                                                                          null);
+                    "askask", null, TEST_ACCOUNTID, false, null, null);
                 adapterId = createBroadSoftAdapter.getResult().toString();
                 adapterConfig = AdapterConfig.getAdapterConfig(adapterId);
                 adapterConfig.setAccountType(type);
                 adapterConfig.setXsiSubscription(TEST_PUBLIC_KEY);
                 updateAdapterAsPrivate(isPrivate, adapterConfig);
                 adapterConfig.update();
-                VoiceXMLRESTProxy.dial(addressNameMap, message, adapterConfig, adapterConfig.getOwner(), null);
+                VoiceXMLRESTProxy.dial(addressNameMap, message, adapterConfig, adapterConfig.getOwner(), null, type);
                 break;
             default:
                 break;


### PR DESCRIPTION
Added feature to pass accountType in the outbound call request. Added unit tests: trialMessagePlayedWithSharingPostPaidAccountOutBoundTest in CMServletIT and trialMessagePlayedWithSharingPostPaidAccountOutBoundTest, trialMessageNotPlayedWithSharingPostPaidAccountInboundTest in VoiceXMLServlet tests